### PR TITLE
syscall/js go 1.12

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -164,14 +164,14 @@ func main() {
 
 	//// Drawing the Cube ////
 	movMatrix := mgl32.Ident4()
-	var renderFrame js.Callback
+	var renderFrame js.Func
 	var tmark float32
 	var rotation = float32(0)
 
 	// Bind to element array for draw function
 	gl.Call("bindBuffer", glTypes.ElementArrayBuffer, indexBuffer)
 
-	renderFrame = js.NewCallback(func(args []js.Value) {
+	renderFrame = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		// Calculate rotation rate
 		now := float32(args[0].Float())
 		tdiff := now - tmark
@@ -201,6 +201,8 @@ func main() {
 
 		// Call next frame
 		js.Global().Call("requestAnimationFrame", renderFrame)
+		
+		return nil;
 	})
 	defer renderFrame.Release()
 


### PR DESCRIPTION
js.Callback is renamed to js.Func, js.NewCallback() to js.FuncOf()

new interface (https://golang.org/pkg/syscall/js/#FuncOf):
var cb js.Func
cb = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
        fmt.Println("button clicked")
        cb.Release() // release the function if the button will not be clicked again
        return nil
})
js.Global().Get("document").Call("getElementById", "myButton").Call("addEventListener", "click", cb)